### PR TITLE
Fix(performance): Eliminate CLS with a high-fidelity skeleton loader

### DIFF
--- a/ora-fixa/src/lib/components/landing/skeleton-booking.svelte
+++ b/ora-fixa/src/lib/components/landing/skeleton-booking.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
+</script>
+
+<section id="booking" class="py-24 text-center">
+	<div class="container mx-auto px-4 lg:px-6">
+		<div class="mx-auto max-w-4xl">
+			<div class="mb-12 flex flex-col items-center space-y-8">
+				<Skeleton class="h-8 w-32 md:h-9 md:w-36" />
+				<Skeleton class="md:w-140 w-85 h-9 md:h-12" />
+				<Skeleton class="md:w-160 w-90 h-20 md:h-7" />
+				<Skeleton class="md:w-224 w-90 h-150 md:h-100" />
+			</div>
+		</div>
+	</div>
+</section>


### PR DESCRIPTION
### ## Context

The dynamic loading of the `<Booking />` component on the landing page was causing a significant **Cumulative Layout Shift (CLS)**. This negatively impacted the Core Web Vitals score and created a jarring user experience as the page content would "jump" after the initial render.

### ## Implementation 

This PR resolves the CLS issue by replacing the simple loading text with a high-fidelity **Skeleton Loader** (`<BookingPlaceholder />`).

-   The new placeholder component mimics the exact layout, spacing, and structure of the real `<Booking />` component.
-   This ensures the correct vertical space is reserved on the initial, prerendered page load.
-   When the dynamic `<Booking />` component is loaded and hydrated on the client, it fills the pre-allocated space, resulting in zero layout shift.

### ## Verification

1.  **[x]** Generate a local production build with `npm run build` and serve it using `npm run preview`.
2.  **[x]** Run a Lighthouse audit on the local preview server.
3.  **[x]** Confirm that the **Cumulative Layout Shift (CLS)** score is now **0** (or near-zero).
4.  **[x]** Visually confirm that the page no longer jumps when the booking module loads.